### PR TITLE
Removed module.parent check

### DIFF
--- a/nsh.js
+++ b/nsh.js
@@ -185,6 +185,4 @@ function prompt(){
 }
 
 // Main method
-if(!module.parent){
-  prompt();
-}
+prompt();


### PR DESCRIPTION
Currently checking for module.parent or other things is not used anymore since package.json provides mechanism for a package work at the same time as a library and as an executable, so this checks similar to the Python ones are not needed anymore, and also allow to NodeOS env.js to use less memory.